### PR TITLE
Remove call-webhook job from workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -77,11 +77,3 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-  call-webhook:
-    runs-on: ubuntu-latest
-    needs: [back-end, front-end]
-    if: ${{ github.event_name != 'pull_request' }}
-    steps:
-      - name: Call Webhook
-        run: |
-          curl -X POST ${{ secrets.WEBHOOK_URL }}


### PR DESCRIPTION
Removed the call-webhook job from the Docker image workflow.