### PR TITLE
Fix prisma, add health check to docker image

### DIFF
--- a/back-end/Dockerfile
+++ b/back-end/Dockerfile
@@ -6,16 +6,24 @@ COPY package*.json ./
 COPY tsconfig*.json ./
 COPY . ./
 RUN npm ci
+RUN npx prisma generate
 RUN npm run build
 
 # production environment
 FROM node:lts-slim
 WORKDIR /app
+ENV NODE_PORT=3000
+EXPOSE $NODE_PORT
 COPY --from=build /app/package*.json ./
 COPY --from=build /app/dist ./
+COPY --from=build /app/node_modules/@prisma ./node_modules/@prisma
+COPY --from=build /app/node_modules/.prisma ./node_modules/.prisma
 COPY --from=build /app/src/.generated ./.generated
 COPY --from=build /app/prisma ./prisma
 RUN npm ci --omit=dev
-RUN apt-get update -y && apt-get install -y openssl
+RUN apt-get update -y && apt-get install -y openssl curl
+RUN chown -R 1000:1000 /app
 USER 1000
+HEALTHCHECK --interval=5s --timeout=10s --start-period=5s --retries=5 \
+  CMD curl -f --max-time 8 --silent http://localhost:${NODE_PORT}/health || exit 1
 CMD ["npm", "run", "prod:deploy"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,6 @@ services:
       - ADMIN_PASSWORD=${ADMIN_PASSWORD}
       - COOKIE_SECRET=${COOKIE_SECRET}
     restart: unless-stopped
-    healthcheck:
-      test:  wget --spider --tries=1 --no-verbose http://localhost:${NODE_PORT:-3000}/health
     depends_on:
       db:
         condition: service_healthy
@@ -39,3 +37,7 @@ services:
       - /portainer/postgres/games-${NODE_ENV}:/var/lib/postgresql/data
     healthcheck:
       test: /usr/bin/pg_isready
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 30s


### PR DESCRIPTION
This pull request updates the Docker configuration for the back-end service to improve Prisma integration, container health checks, and production readiness. The most important changes are grouped below.

**Dockerfile improvements:**

* Added `RUN npx prisma generate` to ensure Prisma client code is generated during the build process.
* Set `NODE_PORT=3000` as an environment variable and exposed it for container networking.
* Added explicit copying of Prisma-related directories (`@prisma` and `.prisma`) from the build stage to the production image to support runtime database operations.
* Improved health checks by adding a `HEALTHCHECK` instruction using `curl` to verify the service is up and responding at `/health`.
* Changed ownership of `/app` directory to user 1000 for better security and compliance.

**Healthcheck and service orchestration changes:**

* Removed the application healthcheck from `docker-compose.yml` since health is now managed inside the Dockerfile.
* Enhanced the PostgreSQL service healthcheck in `docker-compose.yml` by adding interval, timeout, retries, and start period parameters for more robust readiness detection.