### PR TITLE
Update binary targets

### DIFF
--- a/back-end/prisma/schema.prisma
+++ b/back-end/prisma/schema.prisma
@@ -2,8 +2,9 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-  provider = "prisma-client-js"
-  output   = "../src/.generated/prisma/"
+  provider      = "prisma-client-js"
+  output        = "../src/.generated/prisma/"
+  binaryTargets = ["native", "debian-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
This pull request makes a minor update to the Prisma client generator configuration. The change adds support for the `debian-openssl-3.0.x` binary target, which can help ensure compatibility when deploying on Debian systems with OpenSSL 3.0.

([back-end/prisma/schema.prismaR7](diffhunk://#diff-caaff379b90de8f7a283d5bcda2994da0d9ac60416dacdf454b6555f973fd151R7))